### PR TITLE
Fix incorrect innobackupex args (fixed gate)

### DIFF
--- a/trove/guestagent/strategies/restore/mysql_impl.py
+++ b/trove/guestagent/strategies/restore/mysql_impl.py
@@ -106,9 +106,12 @@ class InnoBackupEx(base.RestoreRunner, MySQLRestoreMixin):
     """Implementation of Restore Strategy for InnoBackupEx."""
     __strategy_name__ = 'innobackupex'
     base_restore_cmd = 'sudo xbstream -x -C %(restore_location)s'
-    base_prepare_cmd = ('sudo innobackupex --apply-log %(restore_location)s'
+    base_prepare_cmd = ('sudo innobackupex'
                         ' --defaults-file=%(restore_location)s/backup-my.cnf'
-                        ' --ibbackup xtrabackup 2>/tmp/innoprepare.log')
+                        ' --ibbackup=xtrabackup'
+                        ' --apply-log'
+                        ' %(restore_location)s'
+                        ' 2>/tmp/innoprepare.log')
 
     def __init__(self, *args, **kwargs):
         super(InnoBackupEx, self).__init__(*args, **kwargs)
@@ -151,11 +154,11 @@ class InnoBackupEx(base.RestoreRunner, MySQLRestoreMixin):
 class InnoBackupExIncremental(InnoBackupEx):
     __strategy_name__ = 'innobackupexincremental'
     incremental_prep = ('sudo innobackupex'
+                        ' --defaults-file=%(restore_location)s/backup-my.cnf'
+                        ' --ibbackup=xtrabackup'
                         ' --apply-log'
                         ' --redo-only'
                         ' %(restore_location)s'
-                        ' --defaults-file=%(restore_location)s/backup-my.cnf'
-                        ' --ibbackup xtrabackup'
                         ' %(incremental_args)s'
                         ' 2>/tmp/innoprepare.log')
 

--- a/trove/tests/unittests/guestagent/test_backups.py
+++ b/trove/tests/unittests/guestagent/test_backups.py
@@ -58,15 +58,21 @@ SQLDUMP_BACKUP_EXTRA_OPTS = (SQLDUMP_BACKUP_RAW %
                              {'extra_opts': '--events --routines --triggers'})
 XTRA_RESTORE_RAW = "sudo xbstream -x -C %(restore_location)s"
 XTRA_RESTORE = XTRA_RESTORE_RAW % {'restore_location': '/var/lib/mysql'}
-XTRA_INCR_PREPARE = ("sudo innobackupex --apply-log"
-                     " --redo-only /var/lib/mysql"
+XTRA_INCR_PREPARE = ("sudo innobackupex"
                      " --defaults-file=/var/lib/mysql/backup-my.cnf"
-                     " --ibbackup xtrabackup %(incr)s"
+                     " --ibbackup=xtrabackup"
+                     " --apply-log"
+                     " --redo-only"
+                     " /var/lib/mysql"
+                     " %(incr)s"
                      " 2>/tmp/innoprepare.log")
 SQLDUMP_RESTORE = "sudo mysql"
-PREPARE = ("sudo innobackupex --apply-log /var/lib/mysql "
-           "--defaults-file=/var/lib/mysql/backup-my.cnf "
-           "--ibbackup xtrabackup 2>/tmp/innoprepare.log")
+PREPARE = ("sudo innobackupex"
+           " --defaults-file=/var/lib/mysql/backup-my.cnf"
+           " --ibbackup=xtrabackup"
+           " --apply-log"
+           " /var/lib/mysql"
+           " 2>/tmp/innoprepare.log")
 CRYPTO_KEY = "default_aes_cbc_key"
 
 CBBACKUP_CMD = "tar cpPf - /tmp/backups"


### PR DESCRIPTION
A recent release of Percona XtraBackup has tightened up the
validation of options passed to the innobackupex script.

See:
https://www.percona.com/doc/percona-xtrabackup/2.3/release-notes/2.3/2.3.4.html
https://bugs.launchpad.net/percona-xtrabackup/+bug/1533542

The options supplied to innobackupex in the MySQL restore strategy
are slightly incorrect - this was ignored previously but now causes
the backups to fail.

The options are now specified correctly.

Change-Id: Ic4671998f0c4467f17caa60cbb3106f49c505a2e
Closes-Bug: #1558794

(cherry picked from commit 5f0d88c)

Conflicts:
	trove/tests/unittests/guestagent/test_backups.py