### PR TITLE
Fail on deleting non-existing database

### DIFF
--- a/trove/extensions/mysql/models.py
+++ b/trove/extensions/mysql/models.py
@@ -265,3 +265,13 @@ class Schemas(object):
                                         mysql_schema.collate,
                                         mysql_schema.character_set))
         return model_schemas, next_marker
+
+    @classmethod
+    def find(cls, context, instance_id, schema_id):
+        load_and_verify(context, instance_id)
+        client = create_guest_client(context, instance_id)
+        model_schemas, _ = cls.load_with_client(client, 1, schema_id, True)
+        if model_schemas and model_schemas[0].name == schema_id:
+            return model_schemas[0]
+
+        return None

--- a/trove/extensions/mysql/service.py
+++ b/trove/extensions/mysql/service.py
@@ -326,6 +326,8 @@ class SchemaController(wsgi.Controller):
             try:
                 schema = guest_models.ValidatedMySQLDatabase()
                 schema.name = id
+                if not models.Schemas.find(context, instance_id, id):
+                    raise exception.DatabaseNotFound(uuid=id)
                 models.Schema.delete(context, instance_id, schema.serialize())
             except (ValueError, AttributeError) as e:
                 raise exception.BadRequest(msg=str(e))

--- a/trove/guestagent/datastore/mysql_common/service.py
+++ b/trove/guestagent/datastore/mysql_common/service.py
@@ -452,7 +452,7 @@ class BaseMySqlAdmin(object):
             next_marker = None
             LOG.debug("database_names = %r." % database_names)
             for count, database in enumerate(database_names):
-                if count >= limit:
+                if limit is not None and count >= limit:
                     break
                 LOG.debug("database = %s." % str(database))
                 mysql_db = models.MySQLDatabase()
@@ -517,7 +517,7 @@ class BaseMySqlAdmin(object):
             next_marker = None
             LOG.debug("result = " + str(result))
             for count, row in enumerate(result):
-                if count >= limit:
+                if limit is not None and count >= limit:
                     break
                 LOG.debug("user = " + str(row))
                 mysql_user = models.MySQLUser()

--- a/trove/tests/scenario/runners/database_actions_runners.py
+++ b/trove/tests/scenario/runners/database_actions_runners.py
@@ -182,12 +182,12 @@ class DatabaseActionsRunner(TestRunner):
             self.fail("Database still listed after the poll timeout: %ds" %
                       self.GUEST_CAST_WAIT_TIMEOUT_SEC)
 
-    def run_nonexisting_database_delete(self, expected_http_code=202):
-        # Deleting a non-existing database is expected to succeed as if the
-        # database was deleted.
-        self.assert_database_delete(
+    def run_nonexisting_database_delete(
+            self, expected_exception=exceptions.NotFound,
+            expected_http_code=404):
+        self.assert_database_delete_failure(
             self.instance_info.id, self.non_existing_db_def['name'],
-            expected_http_code)
+            expected_exception, expected_http_code)
 
     def run_system_database_delete(
             self, expected_exception=exceptions.BadRequest,


### PR DESCRIPTION
Check that the database exists before deleting it and
fail if it does not.

Trove database API implementation closely followed MySQL
behavior which is to silently ignore deletes on non-existing
databases.
This strategy however no longer works that well with
other datastores which generally fail.

Trove users should be given a consistent experience.
Failing with an explanatory message is safer with respect to other
datastores and it is also consistent with how other Trove API
(user, backup, cluster) work.

Note: guestagent implementation was fix to handle
      limit=None in database (and user) queries.
      N >= None always returns True

Change-Id: I1dc26c7b40d6e4867b145b8470e6e5277e5dcdb4
Closes-Bug: 1293954
(cherry picked from commit 16c6ec83288f79f7b40c952de7d4230154ac90c5)

Conflicts:
trove/extensions/mysql/service.py

Signed-off-by: LiuYang <yippeetry@gmail.com>