### PR TITLE
Make MySQL guestagent setting data_dir correctly in do_prepare.

### DIFF
--- a/trove/guestagent/datastore/mysql_common/manager.py
+++ b/trove/guestagent/datastore/mysql_common/manager.py
@@ -226,6 +226,8 @@ class MySqlManager(manager.Manager):
             # will be changed based on the config template
             # (see MySqlApp.secure()) and restart.
             app.set_data_dir(mount_point + '/data')
+            prepare_conf = app.configuration_manager.parse_configuration()
+            app.configuration_manager.save_configuration(prepare_conf)
             app.start_mysql()
         if backup_info:
             self._perform_restore(backup_info, context,


### PR DESCRIPTION
In do_prepare, when data volume is mounted, 'data_dir' configuration is set in
memory without written to configuration file, so when the database is started
the first time, 'data_dir' is not correct.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>