### PR TITLE
Initialize BadRequest exception with correct message.

### DIFF
--- a/trove/cluster/service.py
+++ b/trove/cluster/service.py
@@ -184,7 +184,7 @@ class ClusterController(wsgi.Controller):
                                    (locality,
                                     "', '".join(locality_domain)))
             if locality not in locality_domain:
-                raise exception.BadRequest(msg=locality_domain_msg)
+                raise exception.BadRequest(message=locality_domain_msg)
 
         context.notification = notification.DBaaSClusterCreate(context,
                                                                request=req)

--- a/trove/extensions/common/service.py
+++ b/trove/extensions/common/service.py
@@ -96,7 +96,7 @@ class DefaultRootController(BaseDatastoreRootController):
         try:
             found_user = self._find_root_user(context, instance_id)
         except (ValueError, AttributeError) as e:
-            raise exception.BadRequest(msg=str(e))
+            raise exception.BadRequest(message=str(e))
         if not found_user:
             raise exception.UserNotFound(uuid="root")
         models.Root.delete(context, instance_id)

--- a/trove/extensions/mysql/service.py
+++ b/trove/extensions/mysql/service.py
@@ -85,7 +85,7 @@ class UserController(wsgi.Controller):
                 model_users = populate_users(users)
                 models.User.create(context, instance_id, model_users)
             except (ValueError, AttributeError) as e:
-                raise exception.BadRequest(msg=str(e))
+                raise exception.BadRequest(message=str(e))
         return wsgi.Result(None, 202)
 
     def delete(self, req, tenant_id, instance_id, id):
@@ -109,7 +109,7 @@ class UserController(wsgi.Controller):
                 if not found_user:
                     user = None
             except (ValueError, AttributeError) as e:
-                raise exception.BadRequest(msg=str(e))
+                raise exception.BadRequest(message=str(e))
             if not user:
                 raise exception.UserNotFound(uuid=id)
             models.User.delete(context, instance_id, user.serialize())
@@ -127,7 +127,7 @@ class UserController(wsgi.Controller):
         try:
             user = models.User.load(context, instance_id, username, host)
         except (ValueError, AttributeError) as e:
-            raise exception.BadRequest(msg=str(e))
+            raise exception.BadRequest(message=str(e))
         if not user:
             raise exception.UserNotFound(uuid=id)
         view = views.UserView(user)
@@ -151,14 +151,14 @@ class UserController(wsgi.Controller):
                 user = models.User.load(context, instance_id, username,
                                         hostname)
             except (ValueError, AttributeError) as e:
-                raise exception.BadRequest(msg=str(e))
+                raise exception.BadRequest(message=str(e))
             if not user:
                 raise exception.UserNotFound(uuid=id)
             try:
                 models.User.update_attributes(context, instance_id, username,
                                               hostname, user_attrs)
             except (ValueError, AttributeError) as e:
-                raise exception.BadRequest(msg=str(e))
+                raise exception.BadRequest(message=str(e))
         return wsgi.Result(None, 202)
 
     def update_all(self, req, body, tenant_id, instance_id):
@@ -189,7 +189,7 @@ class UserController(wsgi.Controller):
                         raise exception.UserNotFound(uuid=user_and_host)
                     model_users.append(mu)
                 except (ValueError, AttributeError) as e:
-                    raise exception.BadRequest(msg=str(e))
+                    raise exception.BadRequest(message=str(e))
             models.User.change_password(context, instance_id, model_users)
         return wsgi.Result(None, 202)
 
@@ -210,7 +210,7 @@ class UserAccessController(wsgi.Controller):
         try:
             user = models.User.load(context, instance_id, username, hostname)
         except (ValueError, AttributeError) as e:
-            raise exception.BadRequest(msg=str(e))
+            raise exception.BadRequest(message=str(e))
         if not user:
             raise exception.UserNotFound(uuid=user_id)
         return user
@@ -330,7 +330,7 @@ class SchemaController(wsgi.Controller):
                     raise exception.DatabaseNotFound(uuid=id)
                 models.Schema.delete(context, instance_id, schema.serialize())
             except (ValueError, AttributeError) as e:
-                raise exception.BadRequest(msg=str(e))
+                raise exception.BadRequest(message=str(e))
         return wsgi.Result(None, 202)
 
     def show(self, req, tenant_id, instance_id, id):

--- a/trove/extensions/security_group/service.py
+++ b/trove/extensions/security_group/service.py
@@ -109,7 +109,7 @@ class SecurityGroupRuleController(wsgi.Controller):
                         body['security_group_rule']['cidr'], context)
                     rules.append(rule)
             except (ValueError, AttributeError) as e:
-                raise exception.BadRequest(msg=str(e))
+                raise exception.BadRequest(message=str(e))
             return rules
 
         tcp_rules = _create_rules(sec_group, tcp_ports, 'tcp')

--- a/trove/instance/service.py
+++ b/trove/instance/service.py
@@ -266,7 +266,7 @@ class InstanceController(wsgi.Controller):
             users = populate_users(body['instance'].get('users', []),
                                    database_names)
         except ValueError as ve:
-            raise exception.BadRequest(msg=ve)
+            raise exception.BadRequest(message=str(ve))
 
         if 'volume' in body['instance']:
             volume_info = body['instance']['volume']
@@ -298,12 +298,12 @@ class InstanceController(wsgi.Controller):
                                    (locality,
                                     "', '".join(locality_domain)))
             if locality not in locality_domain:
-                raise exception.BadRequest(msg=locality_domain_msg)
+                raise exception.BadRequest(message=locality_domain_msg)
             if slave_of_id:
                 dupe_locality_msg = (
                     'Cannot specify locality when adding replicas to existing '
                     'master.')
-                raise exception.BadRequest(msg=dupe_locality_msg)
+                raise exception.BadRequest(message=dupe_locality_msg)
 
         instance = models.Instance.create(context, name, flavor_id,
                                           image_id, databases, users,


### PR DESCRIPTION
Currently some BadRequest raised with a wrong argument 'msg', this leads
to totally helpless informations return by API when errors occurred.
This patch fixes this problem.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>