### PR TITLE
Allow use utf8 (visible) characters in object names.

### DIFF
--- a/trove/common/apischema.py
+++ b/trove/common/apischema.py
@@ -37,6 +37,20 @@ non_empty_string = {
     "pattern": "^.*[0-9a-zA-Z]+.*$"
 }
 
+non_empty_utf8_name = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 255,
+    "pattern": "^\S+$"
+}
+
+non_empty_utf8_desc = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 255,
+    "pattern": "^\S+.*$"
+}
+
 configuration_data_types = {
     "type": "string",
     "minLength": 1,
@@ -327,7 +341,7 @@ instance = {
                 "required": ["name", "flavorRef"],
                 "additionalProperties": True,
                 "properties": {
-                    "name": non_empty_string,
+                    "name": non_empty_utf8_name,
                     "configuration_id": configuration_id,
                     "flavorRef": flavorref,
                     "volume": volume,
@@ -369,7 +383,7 @@ instance = {
                 "properties": {
                     "slave_of": {},
                     "replica_of": {},
-                    "name": non_empty_string,
+                    "name": non_empty_utf8_name,
                     "configuration": configuration_id,
                     "datastore_version": non_empty_string,
                 }
@@ -523,9 +537,9 @@ backup = {
                 "type": "object",
                 "required": ["instance", "name"],
                 "properties": {
-                    "description": non_empty_string,
+                    "description": non_empty_utf8_desc,
                     "instance": uuid,
-                    "name": non_empty_string,
+                    "name": non_empty_utf8_name,
                     "parent_id": uuid,
                     "incremental": boolean_string
                 }
@@ -648,11 +662,11 @@ configuration = {
                 "type": "object",
                 "required": ["values", "name"],
                 "properties": {
-                    "description": non_empty_string,
+                    "description": non_empty_utf8_desc,
                     "values": {
                         "type": "object",
                     },
-                    "name": non_empty_string,
+                    "name": non_empty_utf8_name,
                     "datastore": {
                         "type": "object",
                         "additionalProperties": True,
@@ -674,11 +688,11 @@ configuration = {
                 "type": "object",
                 "required": [],
                 "properties": {
-                    "description": non_empty_string,
+                    "description": non_empty_utf8_desc,
                     "values": {
                         "type": "object",
                     },
-                    "name": non_empty_string
+                    "name": non_empty_utf8_name
                 }
             }
         }

--- a/trove/tests/unittests/backup/test_backup_controller.py
+++ b/trove/tests/unittests/backup/test_backup_controller.py
@@ -43,18 +43,18 @@ class TestBackupController(trove_testtools.TestCase):
         self.assertFalse(validator.is_valid(body))
         errors = sorted(validator.iter_errors(body), key=lambda e: e.path)
         self.assertEqual(1, len(errors))
-        self.assertIn("' ' does not match '^.*[0-9a-zA-Z]+.*$'",
+        self.assertIn("' ' does not match '^\\\\S+$'",
                       errors[0].message)
 
     def test_validate_create_with_invalidname(self):
         body = {"backup": {"instance": self.uuid,
-                           "name": '$#@&?'}}
+                           "name": 'a b\tc\nd'}}
         schema = self.controller.get_schema('create', body)
         validator = jsonschema.Draft4Validator(schema)
         self.assertFalse(validator.is_valid(body))
         errors = sorted(validator.iter_errors(body), key=lambda e: e.path)
         self.assertEqual(1, len(errors))
-        self.assertIn("'$#@&?' does not match '^.*[0-9a-zA-Z]+.*$'",
+        self.assertIn("'a b\\tc\\nd' does not match '^\\\\S+$'",
                       errors[0].message)
 
     def test_validate_create_invalid_uuid(self):

--- a/trove/tests/unittests/instance/test_instance_controller.py
+++ b/trove/tests/unittests/instance/test_instance_controller.py
@@ -138,17 +138,17 @@ class TestInstanceController(trove_testtools.TestCase):
         errors = sorted(validator.iter_errors(body), key=lambda e: e.path)
         self.assertThat(len(errors), Is(1))
         self.assertThat(errors[0].message,
-                        Equals("'     ' does not match '^.*[0-9a-zA-Z]+.*$'"))
+                        Equals("'     ' does not match '^\\\\S+$'"))
 
     def test_validate_create_invalid_name(self):
         body = self.instance
-        body['instance']['name'] = "$#$%^^"
+        body['instance']['name'] = "a b\tc\nd"
         schema = self.controller.get_schema('create', body)
         validator = jsonschema.Draft4Validator(schema)
         self.assertFalse(validator.is_valid(body))
         errors = sorted(validator.iter_errors(body), key=lambda e: e.path)
         self.assertEqual(1, len(errors))
-        self.assertIn("'$#$%^^' does not match '^.*[0-9a-zA-Z]+.*$'",
+        self.assertIn("'a b\\tc\\nd' does not match '^\\\\S+$'",
                       errors[0].message)
 
     def test_validate_create_invalid_locality(self):


### PR DESCRIPTION
With this patch, instance/backup/configuration names can use visible
utf8 characters.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>