### PR TITLE
Fix api exception with unicode tenant name.

### DIFF
--- a/trove/common/auth.py
+++ b/trove/common/auth.py
@@ -22,6 +22,7 @@ import webob.exc
 from trove.common import exception
 from trove.common.i18n import _
 from trove.common import wsgi
+from trove.common.utils import req_to_text
 
 LOG = logging.getLogger(__name__)
 
@@ -64,7 +65,8 @@ class TenantBasedAuth(object):
             LOG.debug(strutils.mask_password(
                       _("Authorized tenant '%(tenant_id)s' request: "
                         "%(request)s") %
-                      {'tenant_id': tenant_id, 'request': request}))
+                      {'tenant_id': tenant_id,
+                       'request': req_to_text(request)}))
             return True
 
         msg = _(

--- a/trove/common/base_wsgi.py
+++ b/trove/common/base_wsgi.py
@@ -42,6 +42,7 @@ from xml.parsers import expat
 from trove.common import base_exception
 from trove.common.i18n import _
 from trove.common import xmlutils
+from trove.common.utils import req_to_text
 
 socket_opts = [
     cfg.IntOpt('backlog',
@@ -331,6 +332,8 @@ class Request(webob.Request):
         if content_type not in allowed_content_types:
             raise base_exception.InvalidContentType(content_type=content_type)
         return content_type
+
+    __str__ = req_to_text
 
 
 class Resource(object):

--- a/trove/common/utils.py
+++ b/trove/common/utils.py
@@ -30,6 +30,7 @@ from oslo_service import loopingcall
 from oslo_utils import importutils
 from oslo_utils import strutils
 from oslo_utils import timeutils
+from oslo_utils.encodeutils import safe_encode
 from passlib import utils as passlib_utils
 import six
 import six.moves.urllib.parse as urlparse
@@ -396,3 +397,28 @@ def to_mb(bytes):
     size = bytes / 1024.0 ** 2
     # Make sure we don't return 0.0 if the size is greater than 0
     return max(round(size, 2), 0.01)
+
+
+def req_to_text(req):
+    """
+    We do a lot request logging for debug, but if the value of one
+    requst header is encoded in utf-8, an UnicodeEncodeError will
+    be raised. So we shoud carefully encode request headers.
+
+    To be consitent with webob, main procedures are copied from
+    webob.Request.as_bytes.
+    """
+    url = req.url
+    host = req.host_url
+    assert url.startswith(host)
+    url = url[len(host):]
+    parts = [safe_encode('%s %s %s' % (req.method, url, req.http_version))]
+
+    for k, v in sorted(req.headers.items()):
+        header = safe_encode('%s: %s' % (k, v))
+        parts.append(header)
+
+    if req.body:
+        parts.extend(safe_encode(req.body))
+
+    return '\r\n'.join(parts).decode(req.charset)


### PR DESCRIPTION
There are a lot request debug logging in Trove, when some values of
headers are encoded in utf8, UnicodeEncodeError will be raised by
webob.Request. Override how webob.Request is represented will fix.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>