### PR TITLE
Support Swift CORS.

### DIFF
--- a/trove/cmd/guest.py
+++ b/trove/cmd/guest.py
@@ -32,7 +32,10 @@ guest_opts = [
     openstack_cfg.StrOpt('guest_id', default=None,
                          help="ID of the Guest Instance."),
     openstack_cfg.StrOpt('tenant_id', default=None,
-                         help="Tenant ID of the Guest Instance.")
+                         help="Tenant ID of the Guest Instance."),
+    openstack_cfg.StrOpt('swift_container_allowed_origins',
+                         default=None,
+                         help="CORS Allowed Origins for Swift Containers.")
 ]
 CONF.register_opts(guest_opts)
 

--- a/trove/common/utils.py
+++ b/trove/common/utils.py
@@ -422,3 +422,21 @@ def req_to_text(req):
         parts.extend(safe_encode(req.body))
 
     return '\r\n'.join(parts).decode(req.charset)
+
+
+def is_valid_origins(origins):
+    """
+    Validate Swift container CORS allowed origins. Validation is exactly same
+    with Ceph RadosGW Swift API.
+    """
+    if origins:
+        origin_list = [o.strip() for o in origins.split(',')]
+        for origin in origin_list:
+            if not origin:
+                return False
+            elif origin.find('*') != origin.rfind('*'):
+                return False
+
+        return True
+
+    return False


### PR DESCRIPTION
1. Add a new configuration: 'swift_container_allowed_origins';
2. When the above configuration is set, when guest_log creating Swift
   container, two additional Swift CORS headers will be appended, which
   will make Swift CORS work.

swift_container_allowed_origins is a set of strings seperated by comma,
wildcard is supported but should only occur only, eg:
'http://*.eayun.com, https://*.eayun.com'.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>