### PR TITLE
Get rid of unnecessary '\r\n' in request body of debug logging.

### DIFF
--- a/trove/common/utils.py
+++ b/trove/common/utils.py
@@ -419,7 +419,7 @@ def req_to_text(req):
         parts.append(header)
 
     if req.body:
-        parts.extend(safe_encode(req.body))
+        parts.extend(['', safe_encode(req.body)])
 
     return '\r\n'.join(parts).decode(req.charset)
 


### PR DESCRIPTION
Request body is not correctly append to represent sequence in 76b29967,
which results '\r\n' inserted bwtween every character in request body of
debug logging.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>