### PR TITLE
Fix incorrectly calling _delete_files_from_swift from eventlet spawn_n.

### DIFF
--- a/trove/taskmanager/models.py
+++ b/trove/taskmanager/models.py
@@ -1181,8 +1181,8 @@ class BuiltInstanceTasks(BuiltInstance, NotifyMixin, ConfigurationMixin):
                 container_name = log.get('container')
                 break
         if have_log:
-            self.pool.spawn_n(self._delete_files_from_swift, (
-                container_name, prefix))
+            self.pool.spawn_n(self._delete_files_from_swift,
+                              container_name, prefix)
 
     def server_status_matches(self, expected_status, server=None):
         if not server:


### PR DESCRIPTION
eventlet.GreenPool.spawn_n should invoke the function and its arguments
directly.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>