### PR TITLE
Disable protected-mode in default config

### DIFF
--- a/trove/templates/redis/config.template
+++ b/trove/templates/redis/config.template
@@ -45,6 +45,25 @@ daemonize yes
 # Trove will override this property based on the underlying OS.
 pidfile /var/run/redis/redis-server.pid
 
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode no
+
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.
 port 6379


### PR DESCRIPTION
the protected-mode is on in default config, lead to sync failed between
master and slave.

Change-Id: I17cc776cba4c7382389b67f5206ade8453c08dc7
Signed-off-by: LiuYang <yippeetry@gmail.com>