### PR TITLE
Fix init RedisApp after restart trove-guestagent

### DIFF
--- a/trove/guestagent/datastore/experimental/redis/service.py
+++ b/trove/guestagent/datastore/experimental/redis/service.py
@@ -102,6 +102,7 @@ class RedisApp(object):
             override_strategy=OneFileOverrideStrategy(revision_dir))
 
         self.admin = self._build_admin_client()
+        self.admin.set_config_command_name(self.get_config_command_name())
         self.status = RedisAppStatus(self.admin)
 
     def _build_admin_client(self):
@@ -222,7 +223,8 @@ class RedisApp(object):
     def get_config_command_name(self):
         """Get current name of the 'CONFIG' command.
         """
-        renamed_cmds = self.configuration_manager.get_value('rename-command')
+        renamed_cmds = self.configuration_manager.get_value(
+            'rename-command') or []
         for name_pair in renamed_cmds:
             if name_pair[0] == 'CONFIG':
                 return name_pair[1]


### PR DESCRIPTION
when restart trove-guestagent.service or vm, the `CONFIG` recommand-name
should be read again.

Change-Id: I80c81114ac57fb399ee01cbd47104fecdb2d3eb1
Signed-off-by: LiuYang <yippeetry@gmail.com>