### PR TITLE
Rebuild RedisAdmin after config set requirepass.

### DIFF
--- a/trove/guestagent/datastore/experimental/redis/service.py
+++ b/trove/guestagent/datastore/experimental/redis/service.py
@@ -37,6 +37,7 @@ LOG = logging.getLogger(__name__)
 TIME_OUT = 1200
 CONF = cfg.CONF
 CLUSTER_CFG = 'clustering'
+REBUILT_NEEDED_CONFIGS = [u'requirepass', ]
 packager = pkg.Package()
 
 
@@ -110,6 +111,10 @@ class RedisApp(object):
 
         return RedisAdmin(password=password, unix_socket_path=socket)
 
+    def _rebuild_admin_client(self):
+        self.admin = self._build_admin_client()
+        self.status.set_client(self.admin)
+
     def install_if_needed(self, packages):
         """
         Install redis if needed do nothing if it is already installed.
@@ -167,6 +172,9 @@ class RedisApp(object):
             args_string = self._join_lists(
                 self._value_converter.to_strings(prop_args), ' ')
             client.config_set(prop_name, args_string)
+            if prop_name in REBUILT_NEEDED_CONFIGS:
+                self._rebuild_admin_client()
+                client = self.admin
 
     def _join_lists(self, items, sep):
         """Join list items (including items from sub-lists) into a string.


### PR DESCRIPTION
RedisAdmin rebuilt is needed after setting requirepass via config set, to avoid client 'NOAUTH Authentication required' exception.

Closes-bug:  http://192.168.15.2/issues/10087

Signed-off-by: Fan Zhang <zh.f@outlook.com>