### PR TITLE
Redis root-enable/root-disable implementation

### DIFF
--- a/trove/common/cfg.py
+++ b/trove/common/cfg.py
@@ -807,7 +807,7 @@ redis_opts = [
                help='Class that implements datastore-specific Guest Agent API '
                     'logic.'),
     cfg.StrOpt('root_controller',
-               default='trove.extensions.common.service.DefaultRootController',
+               default='trove.extensions.redis.service.RedisRootController',
                help='Root controller implementation for redis.'),
     cfg.StrOpt('guest_log_exposed_logs', default='',
                help='List of Guest Logs to expose for publishing.'),

--- a/trove/common/exception.py
+++ b/trove/common/exception.py
@@ -622,3 +622,9 @@ class ImageNotFound(NotFound):
 class DatastoreVersionAlreadyExists(BadRequest):
 
     message = _("A datastore version with the name '%(name)s' already exists.")
+
+
+class SlaveInstanceOperationNotSupported(TroveError):
+
+    message = _("Operation not supported for instances that are slaves of a "
+                "replica.")

--- a/trove/extensions/redis/models.py
+++ b/trove/extensions/redis/models.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Eayun, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+from oslo_log import log as logging
+
+from trove.common import cfg
+from trove.common.remote import create_guest_client
+from trove.extensions.common.models import Root
+from trove.extensions.common.models import load_and_verify
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+class RedisRoot(Root):
+    @classmethod
+    def get_auth_password(cls, context, instance_id):
+        load_and_verify(context, instance_id)
+        password = create_guest_client(context,
+                                       instance_id).get_root_password()
+        return password

--- a/trove/extensions/redis/service.py
+++ b/trove/extensions/redis/service.py
@@ -1,0 +1,188 @@
+# Copyright 2017 Eayun, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+from oslo_log import log as logging
+from trove.common import cfg
+from trove.common import exception
+from trove.common.i18n import _LI
+from trove.common.i18n import _LE
+from trove.common import wsgi
+from trove.extensions.common.service import DefaultRootController
+from trove.extensions.redis.models import RedisRoot
+from trove.extensions.redis.views import RedisRootCreatedView
+from trove.instance.models import DBInstance
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+MANAGER = CONF.datastore_manager if CONF.datastore_manager else 'redis'
+
+
+class RedisRootController(DefaultRootController):
+    def root_create(self, req, body, tenant_id, instance_id, is_cluster):
+        """Enable authentication for Redis instance and its' replica if any
+        """
+        if is_cluster:
+            raise exception.ClusterOperationNotSupported(
+                operation='enable_root')
+
+        is_slave = self._is_slave(tenant_id, instance_id)
+        if is_slave:
+            raise exception.SlaveInstanceOperationNotSupported()
+
+        password = DefaultRootController._get_password_from_body(body)
+        slave_instances = self._get_slaves(tenant_id, instance_id)
+        return self._instance_root_create(req, instance_id, password,
+                                          slave_instances)
+
+    def root_delete(self, req, tenant_id, instance_id, is_cluster):
+        """Disable authentication for Redis instance and its' replica if any
+        """
+        if is_cluster:
+            raise exception.ClusterOperationNotSupported(
+                operation='disable_root')
+
+        is_slave = self._is_slave(tenant_id, instance_id)
+        if is_slave:
+            raise exception.SlaveInstanceOperationNotSupported()
+        slave_instances = self._get_slaves(tenant_id, instance_id)
+        return self._instance_root_delete(req, instance_id, slave_instances)
+
+    def _instance_root_create(self, req, instance_id, password,
+                              slave_instances=None):
+        LOG.debug(_LI("Enabling authentication for instance '%s'.")
+                  % instance_id)
+        LOG.debug(_LI("req : '%s'\n\n") % req)
+        context = req.environ[wsgi.CONTEXT_KEY]
+        user_name = context.user
+
+        origin_auth_password = self._get_origin_auth_password(context,
+                                                              instance_id)
+
+        # Do root-enable and roll back once if operation fails.
+        try:
+            root = RedisRoot.create(context, instance_id,
+                                    user_name, password)
+            if password is None:
+                password = root.password
+        except exception.TroveError:
+            if not self._rollback_once(req, instance_id, origin_auth_password):
+                raise exception.TroveError(
+                    _LE("Failed to do root-enable for instance "
+                        "'%(instance_id)s'.") % {'instance_id': instance_id}
+                )
+            raise
+
+        failed_slaves = []
+        for slave_id in slave_instances:
+            try:
+                LOG.debug(_LI("Enabling authentication for slave instance "
+                              "'%s'.") % slave_id)
+                RedisRoot.create(context, slave_id, user_name, password)
+            except exception.TroveError:
+                failed_slaves.append(slave_id)
+
+        return wsgi.Result(
+            RedisRootCreatedView(root, failed_slaves).data(), 200)
+
+    def _instance_root_delete(self, req, instance_id, slave_instances=None):
+        LOG.debug(_LI("Disabling authentication for instance '%s'.")
+                  % instance_id)
+        LOG.debug(_LI("req : '%s'\n\n") % req)
+        context = req.environ[wsgi.CONTEXT_KEY]
+
+        origin_auth_password = self._get_origin_auth_password(context,
+                                                              instance_id)
+
+        # Do root-disable and roll back once if operation fails.
+        try:
+            RedisRoot.delete(context, instance_id)
+        except exception.TroveError:
+            if not self._rollback_once(req, instance_id, origin_auth_password):
+                raise exception.TroveError(
+                    _LE("Failed to do root-disable for instance "
+                        "'%(instance_id)s'.") % {'instance_id': instance_id}
+                )
+            raise
+
+        failed_slaves = []
+        for slave_id in slave_instances:
+            try:
+                LOG.debug(_LI("Disabling authentication for slave instance "
+                              "'%s'.") % slave_id)
+                RedisRoot.delete(context, slave_id)
+            except exception.TroveError:
+                failed_slaves.append(slave_id)
+
+        if len(failed_slaves) > 0:
+            result = {
+                'failed_slaves': failed_slaves
+            }
+            return wsgi.Result(result, 200)
+
+        return wsgi.Result(None, 204)
+
+    @staticmethod
+    def _rollback_once(req, instance_id, origin_auth_password):
+        LOG.debug(_LI("Rolling back enable/disable authentication "
+                      "for instance '%s'.") % instance_id)
+        context = req.environ[wsgi.CONTEXT_KEY]
+        user_name = context.user
+        try:
+            if origin_auth_password is None:
+                # Instance never did root-enable before.
+                RedisRoot.delete(context, instance_id)
+            else:
+                # Instance has done root-enable successfully before.
+                # So roll back with original password.
+                RedisRoot.create(context, instance_id, user_name,
+                                 origin_auth_password)
+        except exception.TroveError:
+            LOG.debug("Rolling back failed for instance '%s'" % instance_id)
+            return False
+        return True
+
+    @staticmethod
+    def _is_slave(tenant_id, instance_id):
+        args = {'id': instance_id, 'tenant_id': tenant_id}
+        instance_info = DBInstance.find_by(**args)
+        slave_of_id = instance_info.slave_of_id
+        return bool(slave_of_id)
+
+    @staticmethod
+    def _get_slaves(tenant_id, instance_or_cluster_id):
+        LOG.debug(_LI("Getting non-deleted slaves of instance '%s', "
+                      "if any.") % instance_or_cluster_id)
+        args = {'slave_of_id': instance_or_cluster_id, 'tenant_id': tenant_id}
+        db_infos = DBInstance.find_all(**args)
+        slaves = []
+        for db_info in db_infos:
+            if not db_info.deleted:
+                slaves.append(db_info.id)
+        return slaves
+
+    @staticmethod
+    def _get_origin_auth_password(context, instance_id):
+        # Check if instance did root-enable before and get original password.
+        password = None
+        if RedisRoot.load(context, instance_id):
+            try:
+                password = RedisRoot.get_auth_password(context, instance_id)
+            except exception.TroveError:
+                raise exception.TroveError(
+                    _LE("Failed to get origin auth password of instance "
+                        "'%(instance_id)s'.") % {'instance_id': instance_id}
+                )
+        return password

--- a/trove/extensions/redis/views.py
+++ b/trove/extensions/redis/views.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Eayun, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+from trove.extensions.common.views import UserView
+
+
+class RedisRootCreatedView(UserView):
+    def __init__(self, user, failed_slaves):
+        self.failed_slaves = failed_slaves
+        super(RedisRootCreatedView, self).__init__(user)
+
+    def data(self):
+        user_dict = {
+            "name": self.user.name,
+            "password": self.user.password
+        }
+        return {"user": user_dict, "failed_slaves": self.failed_slaves}

--- a/trove/guestagent/api.py
+++ b/trove/guestagent/api.py
@@ -178,6 +178,13 @@ class API(object):
                                                  'instance_id': self.id})
         self._cast("delete_database", self.version_cap, database=database)
 
+    def get_root_password(self):
+        """Make a synchronous call to get auth password of instance.
+        """
+        LOG.debug("Get auth password of instance %s.", self.id)
+        return self._call("get_root_password", AGENT_HIGH_TIMEOUT,
+                          self.version_cap)
+
     def enable_root(self):
         """Make a synchronous call to enable the root user for
            access from anywhere

--- a/trove/guestagent/datastore/experimental/redis/manager.py
+++ b/trove/guestagent/datastore/experimental/redis/manager.py
@@ -266,3 +266,19 @@ class Manager(manager.Manager):
         LOG.debug("Executing cluster_addslots to assign hash slots %s-%s.",
                   first_slot, last_slot)
         self._app.cluster_addslots(first_slot, last_slot)
+
+    def enable_root(self, context):
+        LOG.debug("Enabling authentication.")
+        return self._app.enable_root()
+
+    def enable_root_with_password(self, context, root_password=None):
+        LOG.debug("Enabling authentication with password.")
+        return self._app.enable_root(root_password)
+
+    def disable_root(self, context):
+        LOG.debug("Disabling authentication.")
+        return self._app.disable_root()
+
+    def get_root_password(self, context):
+        LOG.debug("Getting auth password.")
+        return self._app.get_auth_password()

--- a/trove/guestagent/datastore/manager.py
+++ b/trove/guestagent/datastore/manager.py
@@ -721,6 +721,11 @@ class Manager(periodic_task.PeriodicTasks):
             raise exception.DatastoreOperationNotSupported(
                 operation='change_passwords', datastore=self.manager)
 
+    def get_root_password(self, context):
+        LOG.debug("Getting root password.")
+        raise exception.DatastoreOperationNotSupported(
+            operation='get_root_password', datastore=self.manager)
+
     def enable_root(self, context):
         LOG.debug("Enabling root.")
         raise exception.DatastoreOperationNotSupported(

--- a/trove/guestagent/db/models.py
+++ b/trove/guestagent/db/models.py
@@ -50,6 +50,14 @@ class Base(object):
         """
 
 
+class RedisRootUser(Base):
+
+    def __init__(self, password=None):
+        self._name = '-'
+        self._password = password
+        super(RedisRootUser, self).__init__()
+
+
 class DatastoreSchema(Base):
     """Represents a database schema."""
 

--- a/trove/templates/redis/validation-rules.json
+++ b/trove/templates/redis/validation-rules.json
@@ -118,11 +118,6 @@
             "type": "integer"
         },
         {
-            "name": "requirepass",
-            "restart_required": false,
-            "type": "string"
-        },
-        {
             "name": "maxclients",
             "restart_required": false,
             "min": 0,


### PR DESCRIPTION
Using trove root-enable/root-disable to enable/disable redis
authentication instead of using configuration group. And remove
requirepass item inside of validation-rules.json

Feature-implementation: http://192.168.15.2/issues/10877

Signed-off-by: Fan Zhang <zh.f@outlook.com>
