### PR TITLE
Fix inaccurate error info in validate_can_perform_action

### DIFF
--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -1176,10 +1176,13 @@ class Instance(BuiltInstance):
         Raises exception if an instance action cannot currently be performed.
         """
         # cases where action cannot be performed
+        status_type = 'instance'
         if self.db_info.server_status != 'ACTIVE':
+            status_type = 'server'
             status = self.db_info.server_status
         elif (self.db_info.task_status != InstanceTasks.NONE and
               self.db_info.task_status != InstanceTasks.RESTART_REQUIRED):
+            status_type = 'task'
             status = self.db_info.task_status
         elif not self.datastore_status.status.action_is_allowed:
             status = self.status
@@ -1190,8 +1193,10 @@ class Instance(BuiltInstance):
             return
 
         msg = (_("Instance %(instance_id)s is not currently available for an "
-                 "action to be performed (status was %(action_status)s).") %
-               {'instance_id': self.id, 'action_status': status})
+                 "action to be performed (%(status_type)s status was "
+                 "%(action_status)s).") % {'instance_id': self.id,
+                                           'status_type': status_type,
+                                           'action_status': status})
         LOG.error(msg)
         raise exception.UnprocessableEntity(msg)
 


### PR DESCRIPTION
The error message in validate_can_perform_action() is inaccurate and confusing.
It should be more clear to show which status it is.

Closes-bug: http://192.168.15.2/issues/9627
Signed-off-by: Fan Zhang <zh.f@outlook.com>