### PR TITLE
Fix error info in _validate_can_perform_assign

### DIFF
--- a/trove/common/exception.py
+++ b/trove/common/exception.py
@@ -470,7 +470,7 @@ class ConfigurationAlreadyAttached(TroveError):
 
 class InvalidInstanceState(TroveError):
     message = _("The operation you have requested cannot be executed because "
-                "the instance status is currently: %(status)s.")
+                "the %(status_type)s status is currently: %(status)s.")
 
 
 class NoServiceEndpoint(TroveError):

--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -1208,13 +1208,16 @@ class Instance(BuiltInstance):
 
         # check if the instance is not ACTIVE or has tasks
         status = None
+        status_type = 'server'
         if self.db_info.server_status != InstanceStatus.ACTIVE:
             status = self.db_info.server_status
         elif self.db_info.task_status != InstanceTasks.NONE:
+            status_type = 'task'
             status = self.db_info.task_status.action
 
         if status:
             raise exception.InvalidInstanceState(instance_id=self.id,
+                                                 status_type=status_type,
                                                  status=status)
 
     def unassign_configuration(self):


### PR DESCRIPTION
Make InvalidInstanceState message more specific to show whether it is
server status or task status inside _validate_can_perform_assign.

Closes-bug: http://192.168.15.2/issues/9618
Signed-off-by: Fan Zhang <zh.f@outlook.com>