### PR TITLE
Avoid deleting parent backup failed caused by 404

### DIFF
--- a/trove/backup/models.py
+++ b/trove/backup/models.py
@@ -268,7 +268,10 @@ class Backup(object):
         query = DBBackup.query()
         query = query.filter_by(parent_id=backup_id, deleted=False)
         for child in query.all():
-            cls.delete(context, child.id)
+            try:
+                cls.delete(context, child.id)
+            except exception.NotFound:
+                LOG.info("Backup %s cannot be found." % backup_id)
 
         def _delete_resources():
             backup = cls.get_by_id(context, backup_id)


### PR DESCRIPTION
Catch NotFound exception in trove API level, and return directly to avoid dropping out while deleting parent backup that has multiple children backups.

Closes-bug: http://192.168.15.2/issues/10798
Signed-off-by: Fan Zhang <zh.f@outlook.com>