### PR TITLE
MongoDB: enable to create replicate set cluster.

### DIFF
--- a/trove/cluster/models.py
+++ b/trove/cluster/models.py
@@ -244,10 +244,20 @@ class Cluster(object):
 
     @classmethod
     def create(cls, context, name, datastore, datastore_version,
-               instances, extended_properties, locality):
+               instances, extended_properties, locality, cluster_type):
         locality = srv_grp.ServerGroup.build_scheduler_hint(
             context, locality, name)
         api_strategy = strategy.load_api_strategy(datastore_version.manager)
+        '''
+        MongoDB cluster support two types:sharding, replica-set
+        '''
+        if hasattr(api_strategy, 'support_cluster_type') \
+                and api_strategy.support_cluster_type:
+            return api_strategy.cluster_class.create(context, name, datastore,
+                                                     datastore_version,
+                                                     instances,
+                                                     extended_properties,
+                                                     locality, cluster_type)
         return api_strategy.cluster_class.create(context, name, datastore,
                                                  datastore_version, instances,
                                                  extended_properties,

--- a/trove/cluster/service.py
+++ b/trove/cluster/service.py
@@ -154,6 +154,7 @@ class ClusterController(wsgi.Controller):
                 datastore_version=datastore_version.name)
 
         nodes = body['cluster']['instances']
+        cluster_type = body.get('type', default=None)
         instances = []
         for node in nodes:
             flavor_id = utils.get_id_from_href(node['flavorRef'])
@@ -193,7 +194,7 @@ class ClusterController(wsgi.Controller):
             cluster = models.Cluster.create(context, name, datastore,
                                             datastore_version, instances,
                                             extended_properties,
-                                            locality)
+                                            locality, cluster_type)
         cluster.locality = locality
         view = views.load_view(cluster, req=req, load_servers=False)
         return wsgi.Result(view.data(), 200)


### PR DESCRIPTION
By default, trove MongoDB can only create type of sharding cluster.
this PR aims to add a type named replic_set, which is a another type of cluster within 3/5/7 instances.
Fixes: http://192.168.15.2/issues/11038

**This script for creating MongoDB replica-set:** https://gist.github.com/caisan/efd158a059432d5e7618011a2edfbc5d
