### PR TITLE
Reset log publishing status even exception raised early.

### DIFF
--- a/trove/guestagent/guest_log.py
+++ b/trove/guestagent/guest_log.py
@@ -375,11 +375,13 @@ class GuestLog(object):
         }
         self.context.notification = DBaaSLogPublish(self.context, **payload)
         with StartLogPublishNotification(self.context):
-            self._files_published_attime = 0
-            self._publish_to_container(self._file)
-            self._clear_local_log()
-            self._partially_published = False
-            self._is_publishing = False
+            try:
+                self._files_published_attime = 0
+                self._publish_to_container(self._file)
+                self._clear_local_log()
+                self._partially_published = False
+            finally:
+                self._is_publishing = False
 
     def publish_log(self):
         if self._is_publishing:


### PR DESCRIPTION
During log publishing, various errors will cause the publishing failed,
exceptions should be ignored and publishing status should be reset.

Fixes: http://192.168.15.2/issues/10284

Change-Id: I0b35e54a32d443b3201a29bcbe45fc875e2dd92b
Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>