### PR TITLE
Child processes should always be killed in backup runner.

### DIFF
--- a/trove/guestagent/strategies/backup/base.py
+++ b/trove/guestagent/strategies/backup/base.py
@@ -74,9 +74,9 @@ class BackupRunner(Strategy):
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Clean up everything."""
-        if exc_type is not None:
-            return False
-
+        # Note:
+        # All child processes should always be killed even the context
+        # exits by an exception.
         if getattr(self, 'process', None):
             try:
                 # Send a sigterm to the session leader, so that all
@@ -88,6 +88,11 @@ class BackupRunner(Strategy):
             except OSError:
                 # Already stopped
                 pass
+
+        if exc_type is not None:
+            return False
+
+        if getattr(self, 'process', None):
             utils.raise_if_process_errored(self.process, BackupError)
             if not self.check_process():
                 raise BackupError


### PR DESCRIPTION
In stream_backup_to_storage, uploading to backup end may failed with
an exception, then backup runner context will exits and reraise the
exception, but child proccesses will be left running. When
innobackupex is used for MySQL backup, this may cause the whole
service being locked. So child processes should always be killed when
the context exits.

Fixes: http://192.168.15.2/issues/10887

Change-Id: If27d3c1c8b6e6e79c44f6a71d8650a47cd9838c7
Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>