### PR TITLE
 Update port security group to trove's own security group.

### DIFF
--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -35,6 +35,7 @@ from trove.common.remote import create_cinder_client
 from trove.common.remote import create_dns_client
 from trove.common.remote import create_guest_client
 from trove.common.remote import create_nova_client
+from trove.common.remote import create_neutron_client
 from trove.common import server_group as srv_grp
 from trove.common import template
 from trove.common import utils
@@ -601,6 +602,7 @@ class BaseInstance(SimpleInstance):
         self._guest = None
         self._nova_client = None
         self._volume_client = None
+        self._neutron_client = None
         self._server_group = None
         self._server_group_loaded = False
         self.pool = eventlet.GreenPool()
@@ -670,6 +672,12 @@ class BaseInstance(SimpleInstance):
         if not self._nova_client:
             self._nova_client = create_nova_client(self.context)
         return self._nova_client
+
+    @property
+    def neutron_client(self):
+        if not self._neutron_client:
+            self._neutron_client = create_neutron_client(self.context)
+        return self._neutron_client
 
     def update_db(self, **values):
         self.db_info = DBInstance.find_by(id=self.id, deleted=False)

--- a/trove/taskmanager/models.py
+++ b/trove/taskmanager/models.py
@@ -385,15 +385,22 @@ class FreshInstanceTasks(FreshInstance, NotifyMixin, ConfigurationMixin):
         # in the template definition.
         if CONF.trove_security_groups_support and not use_heat:
             try:
-                security_groups = self._create_secgroup(datastore_manager)
+                security_groups, security_id = self._create_secgroup(
+                    datastore_manager)
+                LOG.debug("Successfully created security group for "
+                          "instance: %s" % self.id)
+                for nic in nics:
+                    if 'port-id' in nic:
+                        port_id = nic['port-id']
+                        body = {'port': {'security_groups': [security_id]}}
+                        self.neutron_client.update_port(port_id, body=body)
+                        LOG.debug("Successfully updated security group for "
+                                  "port: %s" % port_id)
             except Exception as e:
-                msg = (_("Error creating security group for instance: %s") %
+                msg = (_("Error processing security group for instance: %s") %
                        self.id)
                 err = inst_models.InstanceTasks.BUILDING_ERROR_SEC_GROUP
                 self._log_and_raise(e, msg, err)
-            else:
-                LOG.debug("Successfully created security group for "
-                          "instance: %s" % self.id)
 
         files = self.get_injected_files(datastore_manager)
         cinder_volume_type = volume_type or CONF.cinder_volume_type
@@ -1022,7 +1029,7 @@ class FreshInstanceTasks(FreshInstance, NotifyMixin, ConfigurationMixin):
         self._create_rules(security_group, udp_ports, 'udp')
         if icmp:
             self._create_rules(security_group, None, 'icmp')
-        return [security_group["name"]]
+        return [security_group["name"]], security_group['id']
 
     def _create_rules(self, s_group, ports, protocol):
         err = inst_models.InstanceTasks.BUILDING_ERROR_SEC_GROUP


### PR DESCRIPTION
While creating trove instance with port-id assigned，nova will create
instance with port's security group instead of trove's security group. But
we should definitely use trove's own security group.

Cloese-bug: http://192.168.15.2/issues/10278
Signed-off-by: Fan Zhang <zh.f@outlook.com>