### PR TITLE
Fix redis password with #

### DIFF
--- a/trove/common/stream_codecs.py
+++ b/trove/common/stream_codecs.py
@@ -262,6 +262,7 @@ class PropertiesCodec(StreamCodec):
     QUOTING_MODE = csv.QUOTE_MINIMAL
     STRICT_MODE = False
     SKIP_INIT_SPACE = True
+    SUPPORT_INLINE_COMMENTS = True
 
     def __init__(self, delimiter=' ', comment_markers=('#'),
                  unpack_singletons=True, string_mappings=None):
@@ -334,9 +335,9 @@ class PropertiesCodec(StreamCodec):
         return data_dict
 
     def _strip_comments(self, value):
-        # Strip in-line comments.
-        for marker in self._comment_markers:
-            value = value.split(marker)[0]
+        if self.SUPPORT_INLINE_COMMENTS:
+            for marker in self._comment_markers:
+                value = value.split(marker)[0]
         return value.strip()
 
     def _to_rows(self, header, items):

--- a/trove/guestagent/datastore/experimental/redis/service.py
+++ b/trove/guestagent/datastore/experimental/redis/service.py
@@ -44,6 +44,11 @@ SYS_OVERRIDES_AUTH = 'auth_password'
 packager = pkg.Package()
 
 
+class RedisPropertiesCodec(PropertiesCodec):
+    """Special codec for Redis"""
+    SUPPORT_INLINE_COMMENTS = False
+
+
 class RedisAppStatus(service.BaseDbStatus):
     """
     Handles all of the status updating for the redis guest agent.
@@ -99,7 +104,7 @@ class RedisApp(object):
         self.configuration_manager = ConfigurationManager(
             system.REDIS_CONFIG,
             system.REDIS_OWNER, system.REDIS_OWNER,
-            PropertiesCodec(
+            RedisPropertiesCodec(
                 unpack_singletons=False,
                 string_mappings=config_value_mappings
             ), requires_root=True,


### PR DESCRIPTION
Currently, trove stripes in-line comments inside
trove.common.stream_codecs.PropertiesCodec, but it will cause a bug when
enabling root in redis with password like '@#$' or something including '#'
character.

First, add class property ``SUPPORT_INLINE_COMMENTS`` in PropertiesCodec
which default value is True to control whether skipping in-line commnets
check or not. Then, We create  RedisPropertiesCodec from ProtiesCodec
but with property ``SUPPRORT_INLINE_COMMENTS=False`` in order to skip the check
to support redis password with ``#``.


Closes-bug: http://redmine.eayun.net/issues/11176
Signed-off-by: Fan Zhang <zh.f@outlook.com>