### PR TITLE
MongoDB: fix return values of _create_replics_set

### DIFF
--- a/trove/common/strategies/cluster/experimental/mongodb/taskmanager.py
+++ b/trove/common/strategies/cluster/experimental/mongodb/taskmanager.py
@@ -350,6 +350,7 @@ class MongoDbClusterTasks(task_models.ClusterTasks):
         replica_set = self.get_guest(primary_member).get_replica_set_name()
         LOG.debug('creating replica set %s as cluster %s'
                   % (replica_set, self.id))
+        return True
 
     def _get_running_query_router_id(self):
         """Get a query router in this cluster that is in the RUNNING state."""


### PR DESCRIPTION
In the mongodb/taskmanager.py, normally _create_replica_set() return True. When it not return True,
This fault cause stop buildding cluster, the status of cluster is None, but the status of instances stay in BUILD. Changing the return value to True to solve the porblem. 

Fixes: http://192.168.15.2/issues/11190