### PR TITLE
monior fixes for Trove database monitoring

### DIFF
--- a/trove/guestagent/datastore/experimental/mongodb/meteringapp.py
+++ b/trove/guestagent/datastore/experimental/mongodb/meteringapp.py
@@ -30,11 +30,11 @@ class MongoMeteringApp(MeteringApp):
             connections_current = serverStatus['connections']['current']
             connections_available = serverStatus['connections']['available']
             maxConns = int(connections_current) + int(connections_available)
-            if float(maxConns) != 0:
+            if maxConns != 0:
                 conns_userate = float(connections_current) / float(maxConns)
             else:
                 conns_userate = 0
-            # insert,query,update,delete,getmore,command,total
+            # insert, query, update, delete, getmore, command, total
             op_mappings = {
                 'insert': 'mongo.insert.requests',
                 'query': 'mongo.query.requests',

--- a/trove/guestagent/datastore/experimental/redis/meteringapp.py
+++ b/trove/guestagent/datastore/experimental/redis/meteringapp.py
@@ -40,8 +40,9 @@ class RedisMeteringApp(MeteringApp):
     def countkeys(self, info):
         keys = 0
         for i in range(REDIS_DB_NUMBER):
-            if ('db' + str(i)) in info:
-                keys += int(info['db' + str(i)]['keys'])
+            dbname = 'db' + str(i)
+            if dbname in info:
+                keys += int(info[dbname]['keys'])
         return keys
 
     def get_counter(self):

--- a/trove/guestagent/datastore/manager.py
+++ b/trove/guestagent/datastore/manager.py
@@ -937,7 +937,7 @@ class Manager(periodic_task.PeriodicTasks):
         notifier.info(context, 'trove_database.meter', self.metering_data)
         self.last_report = ts
 
-    def guest_eayun_monitor_update(self, context, configuration=None):
+    def guest_eayun_monitor_update(self, context, configuration):
         """This method is to modify the configuration, and restart
         the metering_loop and the metering_notification.
         """
@@ -964,7 +964,7 @@ class Manager(periodic_task.PeriodicTasks):
             config.write(open(FILEPATH, "w"))
 
             if self.eayun_monitor_enabled is False:
-                self.metering_notification_task.stop()
+                self.metering_loop_task.stop()
                 self.metering_notification_task.stop()
             else:
                 def calc_initial_delay(last_time, old_interval):

--- a/trove/instance/service.py
+++ b/trove/instance/service.py
@@ -531,12 +531,12 @@ class InstanceController(wsgi.Controller):
             raise exception.BadRequest(_("enabled must be bool."))
         measure_interval = body.get('measure_interval')
         if measure_interval and (not isinstance(measure_interval, int) or
-                                 measure_interval < 0):
+                                 measure_interval <= 0):
             raise exception.BadRequest(_(
                 "measure_interval must be int and greater than 0."))
         report_interval = body.get('report_interval')
         if report_interval and (not isinstance(report_interval, int) or
-                                report_interval < 0):
+                                report_interval <= 0):
             raise exception.BadRequest(_(
                 "report_interval must be int and greater than 0."))
         context = req.environ[wsgi.CONTEXT_KEY]


### PR DESCRIPTION
1. maxConns is int type, not need float()
2. need a space after the comma
3. 'db' + str (i) need stored in a temporary variable
4. 'configuration' parameter do not need to specify the default value
5. interval need to consider equal to 0

Fix for github pull request #40 hunt's review comment

Signed-off-by: lijinhui <jinhui23.li@gmail.com>