### PR TITLE
MongoDB: create os_mongo_admin_creds on all replica nodes

### DIFF
--- a/trove/common/strategies/cluster/experimental/mongodb/guestagent.py
+++ b/trove/common/strategies/cluster/experimental/mongodb/guestagent.py
@@ -68,10 +68,10 @@ class MongoDbGuestAgentAPI(guest_api.API):
         return self._call("get_key", guest_api.AGENT_LOW_TIMEOUT,
                           self.version_cap)
 
-    def prep_primary(self):
+    def prep_primary(self, password):
         LOG.debug("Preparing member to be primary member.")
         return self._call("prep_primary", guest_api.AGENT_HIGH_TIMEOUT,
-                          self.version_cap)
+                          self.version_cap, password=password)
 
     def create_admin_user(self, password):
         LOG.debug("Creating admin user")

--- a/trove/common/strategies/cluster/experimental/mongodb/taskmanager.py
+++ b/trove/common/strategies/cluster/experimental/mongodb/taskmanager.py
@@ -304,10 +304,12 @@ class MongoDbClusterTasks(task_models.ClusterTasks):
         LOG.debug('initializing replica set on %s' % primary_member.id)
         other_members_ips = []
         try:
+            password = utils.generate_random_password()
             for member in other_members:
                 other_members_ips.append(self.get_ip(member))
+                self.get_guest(member).store_admin_password(password)
                 self.get_guest(member).restart()
-            self.get_guest(primary_member).prep_primary()
+            self.get_guest(primary_member).prep_primary(password)
             self.get_guest(primary_member).add_members(other_members_ips)
         except Exception:
             LOG.exception(_("error initializing replica set"))

--- a/trove/guestagent/datastore/experimental/mongodb/manager.py
+++ b/trove/guestagent/datastore/experimental/mongodb/manager.py
@@ -248,9 +248,9 @@ class Manager(manager.Manager):
         LOG.debug("Getting the cluster key.")
         return self.app.get_key()
 
-    def prep_primary(self, context):
+    def prep_primary(self, context, password):
         LOG.debug("Preparing to be primary member.")
-        self.app.prep_primary()
+        self.app.prep_primary(password)
 
     def create_admin_user(self, context, password):
         self.app.create_admin_user(password)

--- a/trove/guestagent/datastore/experimental/mongodb/service.py
+++ b/trove/guestagent/datastore/experimental/mongodb/service.py
@@ -409,9 +409,8 @@ class MongoDBApp(object):
         """
         return self.configuration_manager.get_value(name, default)
 
-    def prep_primary(self):
+    def prep_primary(self, password):
         # Prepare the primary member of a replica set.
-        password = utils.generate_random_password()
         self.create_admin_user(password)
         self.restart()
 


### PR DESCRIPTION
By default, os_mongo_admin_creds.json only store on the primary,
but when primary change to other member node, cannot execute operation with
admin user, this commit create os_mongo_admin_creds.json for all node.
With os_mongo_admin_creds.json on all node, any operation needs admin user can be executed.