### PR TITLE
Fix calculation mistake in innodb_buffer_pool_size

### DIFF
--- a/trove/guestagent/datastore/mysql_common/meteringapp.py
+++ b/trove/guestagent/datastore/mysql_common/meteringapp.py
@@ -30,7 +30,7 @@ class MysqlMeteringApp(MeteringApp):
 
         innodb_buffer_pool_size = \
             mysql_variables.get('innodb_buffer_pool_size')
-        innodb_buffer_pool_size = float(innodb_buffer_pool_size) / 1024
+        innodb_buffer_pool_size = float(innodb_buffer_pool_size) / 1024 / 1024
 
         connections = mysql_status.get('Connections')
 


### PR DESCRIPTION
innodb_buffer_pool_size is in bytes of the buffer pool. According to PRD,
we should convert bytes to MB by dividing 1024 twice, not just once.

Closes-bug: http://redmine.eayun.net/issues/11230
Signed-off-by: Fan Zhang <zh.f@outlook.com>