### PR TITLE
Fix error when updating metering notification task

### DIFF
--- a/trove/guestagent/datastore/manager.py
+++ b/trove/guestagent/datastore/manager.py
@@ -1002,5 +1002,5 @@ class Manager(periodic_task.PeriodicTasks):
                             self.metering_notification
                         )
                     self.metering_notification_task.start(
-                        interval=measure_interval,
+                        interval=report_interval,
                         initial_delay=initial_delay)


### PR DESCRIPTION
It's wrong updating interval of metering notification task with
measure_interval.

Closes-bug: http://redmine.eayun.net/issues/11223
Signed-off-by: Fan Zhang <zh.f@outlook.com>