### PR TITLE
MongoDB: restore a replica set from the backups

### DIFF
--- a/trove/cluster/models.py
+++ b/trove/cluster/models.py
@@ -244,12 +244,14 @@ class Cluster(object):
 
     @classmethod
     def create(cls, context, name, datastore, datastore_version,
-               instances, extended_properties, locality, cluster_type):
+               instances, extended_properties, locality, cluster_type,
+               backup_id):
         locality = srv_grp.ServerGroup.build_scheduler_hint(
             context, locality, name)
         api_strategy = strategy.load_api_strategy(datastore_version.manager)
         '''
         MongoDB cluster support two types:sharding, replica-set
+        :parameter: backup_id only for replica set.
         '''
         if hasattr(api_strategy, 'support_cluster_type') \
                 and api_strategy.support_cluster_type:
@@ -257,7 +259,8 @@ class Cluster(object):
                                                      datastore_version,
                                                      instances,
                                                      extended_properties,
-                                                     locality, cluster_type)
+                                                     locality, cluster_type,
+                                                     backup_id)
         return api_strategy.cluster_class.create(context, name, datastore,
                                                  datastore_version, instances,
                                                  extended_properties,

--- a/trove/guestagent/datastore/experimental/mongodb/manager.py
+++ b/trove/guestagent/datastore/experimental/mongodb/manager.py
@@ -93,7 +93,11 @@ class Manager(manager.Manager):
         if not (self.app.is_query_router or self.app.is_cluster_member):
             self.app.start_db(update_db=True)
 
-        if not cluster_config and backup_info:
+        if ((cluster_config is None or 'shard_id' not in cluster_config)
+                and backup_info):
+            """
+            Add cluster restore, but MongoDB replica-set only
+            """
             self._perform_restore(backup_info, context, mount_point, self.app)
             if service.MongoDBAdmin().is_root_enabled():
                 self.app.status.report_root(context, 'root')


### PR DESCRIPTION
This pr outlines the process for taking MongoDB data
and restoring that data into a new replica set. Restoring the backup data into a single MongoDB,
then init a replica set, finally add other members into the replica set.

Fix : http://192.168.15.2/issues/11203