### PR TITLE
Add where expression to filter the monitor meters

### DIFF
--- a/trove/guestagent/datastore/mysql_common/meteringapp.py
+++ b/trove/guestagent/datastore/mysql_common/meteringapp.py
@@ -17,13 +17,24 @@ from trove.guestagent.datastore.service import MeteringApp
 
 class MysqlMeteringApp(MeteringApp):
     server_type = 'mysql'
+    GLOBAL_VARIABLES = ['max_connections', 'innodb_buffer_pool_size']
+    GLOBAL_STATUS = ['Connections', 'Threads_connected',
+                     'Queries', 'Com_commit', 'Com_rollback', 'Slow_queries',
+                     'Handler_read_rnd_next', 'Innodb_buffer_pool_pages_dirty',
+                     'Innodb_buffer_pool_pages_data',
+                     'Innodb_buffer_pool_reads',
+                     'Innodb_buffer_pool_read_requests', 'Qcache_hits',
+                     'Qcache_inserts', 'Threads_created', 'Threads_running',
+                     'Com_select', 'Com_replace']
 
     def __init__(self, mysql_admin):
         self.mysql_admin = mysql_admin
 
     def get_counter(self):
-        mysql_variables = self.mysql_admin().get_mysql_variables()
-        mysql_status = self.mysql_admin().get_mysql_status()
+        mysql_variables = self.mysql_admin().get_mysql_variables(
+            variable_names=self.GLOBAL_VARIABLES)
+        mysql_status = self.mysql_admin().get_mysql_status(
+            variable_names=self.GLOBAL_STATUS)
         slave_status = self.mysql_admin().get_slave_status()
 
         max_connections = mysql_variables.get('max_connections')

--- a/trove/guestagent/datastore/mysql_common/service.py
+++ b/trove/guestagent/datastore/mysql_common/service.py
@@ -550,18 +550,30 @@ class BaseMySqlAdmin(object):
         user = self._get_user(username, hostname)
         return user.databases
 
-    def get_mysql_variables(self):
+    def get_mysql_variables(self, variable_names=None):
         """Get mysql database variables."""
         with self.local_sql_client(self.mysql_app.get_engine()) as client:
-            data_list = client.execute('show global variables;')
+            if variable_names is not None and isinstance(variable_names, list):
+                expr = ','.join(['%s'] * len(variable_names))
+                data_list = client.execute("show global variables where "
+                                           "Variable_name in (%s) ;" % expr,
+                                           tuple(variable_names))
+            else:
+                data_list = client.execute('show global variables;')
             data_dict = dict(data_list.__iter__())
 
         return data_dict
 
-    def get_mysql_status(self):
+    def get_mysql_status(self, variable_names=None):
         """Get mysql database status."""
         with self.local_sql_client(self.mysql_app.get_engine()) as client:
-            data_list = client.execute('show global status;')
+            if variable_names is not None and isinstance(variable_names, list):
+                expr = ','.join(['%s'] * len(variable_names))
+                data_list = client.execute("show global status where "
+                                           "Variable_name in (%s) ;" % expr,
+                                           tuple(variable_names))
+            else:
+                data_list = client.execute('show global status;')
             data_dict = dict(data_list.__iter__())
 
         return data_dict


### PR DESCRIPTION
In order to reduce full table scan, add where expression to filter the
fileds we actually need when showing global variables and showing global
status in MySQL.

Cloese-bug: http://192.168.15.2/issues/11228
Signed-off-by: Fan Zhang <zh.f@outlook.com>