### PR TITLE
Fix MySQL slave node cannot get the monitoring data

### DIFF
--- a/trove/guestagent/datastore/mysql_common/meteringapp.py
+++ b/trove/guestagent/datastore/mysql_common/meteringapp.py
@@ -26,6 +26,7 @@ class MysqlMeteringApp(MeteringApp):
                      'Innodb_buffer_pool_read_requests', 'Qcache_hits',
                      'Qcache_inserts', 'Threads_created', 'Threads_running',
                      'Com_select', 'Com_replace']
+    SLAVE_STATUS = ['Seconds_Behind_Master']
 
     def __init__(self, mysql_admin):
         self.mysql_admin = mysql_admin
@@ -35,7 +36,8 @@ class MysqlMeteringApp(MeteringApp):
             variable_names=self.GLOBAL_VARIABLES)
         mysql_status = self.mysql_admin().get_mysql_status(
             variable_names=self.GLOBAL_STATUS)
-        slave_status = self.mysql_admin().get_slave_status()
+        slave_status = self.mysql_admin().get_slave_status(
+            columns=self.SLAVE_STATUS)
 
         max_connections = mysql_variables.get('max_connections')
 

--- a/trove/guestagent/datastore/mysql_common/service.py
+++ b/trove/guestagent/datastore/mysql_common/service.py
@@ -578,11 +578,21 @@ class BaseMySqlAdmin(object):
 
         return data_dict
 
-    def get_slave_status(self):
+    def get_slave_status(self, columns=None):
         """Get mysql database slave status."""
+        data_dict = {}
         with self.local_sql_client(self.mysql_app.get_engine()) as client:
-            data_list = client.execute('show slave status;')
-            data_dict = dict(data_list.__iter__())
+            rp = client.execute('show slave status;')
+            result = rp.first()
+            if result is None:
+                LOG.debug("There is no slave status records.")
+            else:
+                if columns is not None and isinstance(columns, list):
+                    for k in columns:
+                        if k in result:
+                            data_dict[k] = result[k]
+                else:
+                    data_dict = dict(result)
 
         return data_dict
 


### PR DESCRIPTION
We do gather monitoring data from one single instance, and when we show
slave status inside a MySQL slave node, we can only get one ROW of data.
There are some columns that we need, not like showing status, we just get
some rows of that view.

Closes-bug: http://192.168.15.2/issues/11253
Signed-off-by: Fan Zhang <zh.f@outlook.com>