### PR TITLE
Fix duplicate InstanceTask code.

### DIFF
--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -1173,7 +1173,7 @@ class Instance(BuiltInstance):
         elif (self.db_info.task_status != InstanceTasks.NONE and
               self.db_info.task_status != InstanceTasks.RESTART_REQUIRED):
             status_type = 'task'
-            status = self.db_info.task_status
+            status = self.db_info.task_status.action
         elif not self.datastore_status.status.action_is_allowed:
             status = self.status
         elif Backup.running(self.id):
@@ -1183,7 +1183,7 @@ class Instance(BuiltInstance):
             return
 
         msg = (_("Instance %(instance_id)s is not currently available for an "
-                 "action to be performed (%(status_type)s status was "
+                 "action to be performed (%(status_type)s status is "
                  "%(action_status)s).") % {'instance_id': self.id,
                                            'status_type': status_type,
                                            'action_status': status})

--- a/trove/instance/tasks.py
+++ b/trove/instance/tasks.py
@@ -91,10 +91,6 @@ class InstanceTasks(object):
     BUILDING_ERROR_VOLUME = InstanceTask(0x52, 'BUILDING',
                                          'Build error: Volume.',
                                          is_error=True)
-    BUILDING_ERROR_TIMEOUT_GA = InstanceTask(0x54, 'ERROR',
-                                             'Build error: '
-                                             'guestagent timeout.',
-                                             is_error=True)
     BUILDING_ERROR_SEC_GROUP = InstanceTask(0x53, 'BUILDING',
                                             'Build error: Secgroup '
                                             'or rule.',
@@ -115,6 +111,10 @@ class InstanceTasks(object):
                                          'Shrinking Cluster Error.',
                                          is_error=True)
     UPGRADING = InstanceTask(0x59, 'UPGRADING', 'Upgrading the instance.')
+    BUILDING_ERROR_TIMEOUT_GA = InstanceTask(0x5a, 'ERROR',
+                                             'Build error: '
+                                             'guestagent timeout.',
+                                             is_error=True)
 
 # Dissuade further additions at run-time.
 InstanceTask.__init__ = None


### PR DESCRIPTION
Each kind of instance tasks should have a unique code,
BUILDING_ERROR_TIMEOUT_GA and BUILDING_ERROR_REPLICA has the same
code(0x54).

It causes the issue 9627 came up again.

The second commit aims at fixing the message showed in exception response.

Cloese-bug: http://192.168.15.2/issues/9627
(cherry picked from commit 2e9ff9aac0b98053a62af5ac3f79ce4c071945e6)
Signed-off-by: Fan Zhang <zh.f@outlook.com>