### PR TITLE
Fix #11289: attribute error of Backup in instance/models.py

### DIFF
--- a/trove/instance/models.py
+++ b/trove/instance/models.py
@@ -842,7 +842,7 @@ class Instance(BuiltInstance):
 
         if backup_id and cluster_config is None:
             call_args['backup_id'] = backup_id
-            Backup.validate_backup_info(context, datastore, backup_id,
+            Backup.validate_for_restore(context, datastore, backup_id,
                                         target_size)
 
         if slave_of_id:


### PR DESCRIPTION
One of attributes of type object Backup in instance/models.py should be
validate_for_resotre, not validate_backup_info.Change this avoid to cause
attribute error of Backup.

Fixes: http://192.168.15.2/issues/11289